### PR TITLE
chore: release version 1.0.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "minimum-stability": "stable",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "autoload": {
         "psr-4": {
             "Webilia\\WP\\": "src/"


### PR DESCRIPTION
## Summary
- bump composer package version to 1.0.17

## Testing
- `composer phpstan` *(fails: Bootstrap file /workspace/wp/dev/phpstan/constants.php does not exist)*
- `composer phpcs` *(fails: FOUND 29 ERRORS AFFECTING 29 LINES in src/Plugin/Feedback.php)*

------
https://chatgpt.com/codex/tasks/task_b_68ae230b6c5c832c9441e0167d325bd5